### PR TITLE
improve the sample's path in README.md and the JXcore's path in the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Now you have the plugin source codes are located under `/hello/jxcore-cordova/io
 Feel free to edit app.js file under `jxcore-cordova/io.jxcore.node/app/jxcore`. (app.js) is your entry point to JXcore's JS.
 Besides, this is the folder you should put all the necessary node modules etc.
 
-Under the `samples` folder, you will find `index.html`. This sample file shows how to integrate JXcore interface into Cordova client side.
+Under the `sample/www` folder, you will find `index.html`. This sample file shows how to integrate JXcore interface into Cordova client side.
 Prior to installing JXcore plugin, you should update Cordova's index.html as shown from this sample file.
 
 In order to add JXcore plugin into your Android, iOS 'hello' project, use the command line given below;

--- a/sample/www/index.html
+++ b/sample/www/index.html
@@ -10,7 +10,7 @@
     <title>Hello World</title>
 
     <script type="text/javascript" charset="utf-8" src="cordova.js"></script>
-    <script type="text/javascript" charset="utf-8" src="jxcore.js"></script>
+    <script type="text/javascript" charset="utf-8" src="plugins/io.jxcore.node/www/jxcore.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
This pull request addresses the first part of jxcore/jxcore-cordova#15:

> The index.html is under sample/www not sample as stated in the readme

The full path of the sample's `index.html` becomes explicitly given in README.md.

This pull request also addresses the “previous first” part of jxcore/jxcore-cordova#15:

> In index.html I had to copy in the following to get a correct path to jxcore.js, not as listed

The full path that leads to `jxcore.js` becomes explicitly given in the sample's `index.html`.
