### PR TITLE
looks like a parenthesis is missing

### DIFF
--- a/io.jxcore.node/www/jxcore.js
+++ b/io.jxcore.node/www/jxcore.js
@@ -100,7 +100,7 @@ var callFunction = function (name, params, callback) {
   args.methodName = name;
   args.params = params;
 
-  callNative("Evaluate", ["cordova.executeJSON(" + JSON.stringify(args)], callback);
+  callNative("Evaluate", ["cordova.executeJSON(" + JSON.stringify(args) + ")"], callback);
 };
 
 jxcore.prototype.call = function () {


### PR DESCRIPTION
A closing parenthesis seems to be missing in a call to `cordova.executeJSON(`.
