### PR TITLE
revise the sample's CSP to allow inline scripts

### DIFF
--- a/sample/www/index.html
+++ b/sample/www/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="format-detection" content="telephone=no"/>
     <meta name="msapplication-tap-highlight" content="no"/>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; media-src *">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; media-src *">
     <!-- WARNING: for iOS 7, remove the width=device-width and height=device-height attributes. See https://issues.apache.org/jira/browse/CB-4323 -->
     <meta name="viewport"
           content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, target-densitydpi=device-dpi"/>


### PR DESCRIPTION
The file `sample/www/index.html` contains an inline script that won't work unless permitted by the Content Security Policy defined in the same file.

This change fixes jxcore/jxcore-cordova#20.
