### PR TITLE
update jxcore version in install_and_run scripts

### DIFF
--- a/install_and_run.bat
+++ b/install_and_run.bat
@@ -12,7 +12,7 @@ cd hello
 jx install git+https://github.com/ktrzeciaknubisa/get-file
 
 @rem get plugin
-jx node_modules/get-file/cli.js jxcore/jxcore-cordova-release 0.0.5/io.jxcore.node.jx
+jx node_modules/get-file/cli.js jxcore/jxcore-cordova-release 0.0.7/io.jxcore.node.jx
 
 @rem downloader tool not needed any more
 rm -rf ./node_modules

--- a/install_and_run.sh
+++ b/install_and_run.sh
@@ -13,7 +13,7 @@ cd hello
 jx install git+https://github.com/ktrzeciaknubisa/get-file
 
 # get plugin
-jx node_modules/get-file/cli.js jxcore/jxcore-cordova-release 0.0.5/io.jxcore.node.jx
+jx node_modules/get-file/cli.js jxcore/jxcore-cordova-release 0.0.7/io.jxcore.node.jx
 
 # downloader tool not needed any more
 rm -rf ./node_modules


### PR DESCRIPTION
it will be good to keep the most recent jxcore-cordova-relese version number in install_and_run scripts and all other places.
maybe it could be done automatically, using "version" attribute from package.json?
