### PR TITLE
makefile: added support for arm64-v8a

### DIFF
--- a/src/android/jni/Android.mk
+++ b/src/android/jni/Android.mk
@@ -1,12 +1,16 @@
 LOCAL_PATH := $(call my-dir)
 JXCORE_OUT_ANDROID := ../jxcore-binaries/
 
+$(info $$TARGET_ARCH is [${TARGET_ARCH}])
+
 include $(CLEAR_VARS)
 LOCAL_MODULE := cares
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libcares_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libcares_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libcares_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -14,8 +18,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := chrome_zlib
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libchrome_zlib_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libchrome_zlib_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libchrome_zlib_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -23,8 +29,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := http_parser
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libhttp_parser_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libhttp_parser_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libhttp_parser_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -32,8 +40,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := openssl
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libopenssl_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libopenssl_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libopenssl_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -41,8 +51,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := sqlite3
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libsqlite3_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libsqlite3_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libsqlite3_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -50,8 +62,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libuv
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libuv_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libuv_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libuv_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -59,8 +73,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libmozjs
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libmozjs_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libmozjs_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libmozjs_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -68,8 +84,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := jxcore_native
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libjx_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libjx_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libjx_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -77,8 +95,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := liblevel
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libleveldb_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libleveldb_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libleveldb_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -86,8 +106,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libsnappy
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libsnappy_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libsnappy_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libsnappy_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -95,8 +117,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libdown
 ifeq ($(TARGET_ARCH),x86)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libleveldown_ia32.a
-else
+else ifeq ($(TARGET_ARCH),arm)
 LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libleveldown_arm.a
+else
+LOCAL_SRC_FILES := $(JXCORE_OUT_ANDROID)libleveldown_arm64.a
 endif
 include $(PREBUILT_STATIC_LIBRARY)
 

--- a/src/android/jni/Application.mk
+++ b/src/android/jni/Application.mk
@@ -1,4 +1,4 @@
 APP_STL := gnustl_static
 APP_CPPFLAGS := -std=gnu++11 
-APP_ABI := armeabi armeabi-v7a x86
+APP_ABI := armeabi armeabi-v7a x86 arm64-v8a
 APP_PLATFORM := android-9


### PR DESCRIPTION
In order to be able to use jxcore on the ARM64 based devices like Amlogic S905 it needs to add build rules to makefiles.

It is necessary accept [this pull request](https://github.com/jxcore/jxcore/pull/838) to build it with no errors using the android-ndk-r10e.
